### PR TITLE
feat: 휴대폰 번호 인증 API 구현

### DIFF
--- a/src/main/java/kh/spring/controller/api/SignupAPIController.java
+++ b/src/main/java/kh/spring/controller/api/SignupAPIController.java
@@ -1,0 +1,56 @@
+package kh.spring.controller.api;
+
+import java.util.HashMap;
+
+import org.json.simple.JSONObject;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import net.nurigo.java_sdk.api.Message;
+import net.nurigo.java_sdk.exceptions.CoolsmsException;
+
+@Controller
+@RequestMapping("/signup/")
+public class SignupAPIController {
+	
+	public static String confirmNumberCheck;
+	
+	@ResponseBody
+	@RequestMapping("confirmPhoneProc")
+	  public String send(String phone) {
+	    String api_key = ""; //발급받은 key 입력
+	    String api_secret = "";
+	    Message coolsms = new Message(api_key, api_secret);
+
+	    int number = (int) (Math.random()*(9999 - 1000 + 1)+1000);
+	    String randomnumber = String.valueOf(number); //난수 생성
+
+	    System.out.println("done");
+	    // 4 params(to, from, type, text) are mandatory. must be filled
+	    HashMap<String, String> params = new HashMap<String, String>();
+	    params.put("to", phone);
+	    params.put("from", ""); //발신자 번호 입력
+	    params.put("type", "SMS");
+	    params.put("text", randomnumber);
+	    params.put("app_version", "test app 1.2"); // application name and version
+
+	    try {
+	      JSONObject obj = (JSONObject) coolsms.send(params);
+	      System.out.println(obj.toString());
+	    } catch (CoolsmsException e) {
+	      System.out.println(e.getMessage());
+	      System.out.println(e.getCode());
+	    }
+	    confirmNumberCheck = randomnumber;
+	    System.out.println(confirmNumberCheck);
+	    return randomnumber;
+	  }
+	
+	@ResponseBody
+	@RequestMapping("confirmNumberProc")
+	public String isValid(String number) {
+		System.out.println("check");
+		return String.valueOf(1);
+	}
+}

--- a/src/main/webapp/WEB-INF/views/signup/signup.jsp
+++ b/src/main/webapp/WEB-INF/views/signup/signup.jsp
@@ -69,7 +69,7 @@
                 <input type="text" class="form-control" id="member_phone" name="member_phone">
             </div>
              <div class="col-4">
-            	<button type="button" class="btn btn-primary">인증받기</button>
+            	<button type="button" class="btn btn-primary" id="member_confirm_send">인증받기</button>
             </div>          	
         </div>
          <div class="form-group row">
@@ -78,7 +78,7 @@
                 <input type="text" class="form-control" id="member_confirm_phone" name="member_confirm_phone">
             </div>
              <div class="col-4">
-            	<button type="button" class="btn btn-primary">인증확인</button>
+            	<button type="button" class="btn btn-primary" id="member_confirm_check">인증확인</button>
             </div>          	
         </div>
         <div class="form-group row">
@@ -245,6 +245,39 @@
 	         result.innerHTML = "패스워드가 일치합니다."
 	      }
 	   }
+	   
+	//휴대폰 번호 인증 API 시작
+	//생성된 인증번호를 저장할 전역변수 선언
+	var confirmNumber ="";
+	
+	$(function(){
+		$("#member_confirm_send").on("click",function(){
+			$.ajax({
+				url:"signup/confirmPhoneProc",
+				data:{phone:$("#member_phone").val()}
+			}).done(function(randomNumber){
+				console.log(randomNumber); //인증번호 확인을 위한 코드 추후 삭제
+				confirmNumber = randomNumber; //생성된 인증번호를 비교하기 위해 가져온 뒤, 변수에 저장
+			})
+		})
+		}
+	)
+	
+	
+	$(function(){
+		$("#member_confirm_check").on("click", function(){	
+			$.ajax({
+				url:"signup/confirmNumberProc",
+				data:{number:$("#member_confirm_phone").val()}
+			}).done(function(result){	
+				if($("#member_confirm_phone").val() == confirmNumber){ //사용자가 입력한 인증번호와 생성된 인증번호를 비교
+			         alert("휴대폰 인증에 성공했습니다.");
+					console.log("성공"); 
+				}else{
+					console.log("f");
+				}})	
+		})
+	})	
 </script>
 </body>
 </html>


### PR DESCRIPTION
## 제목 
휴대폰 번호 인증 API 구현

## 내용
- 회원가입 시 휴대폰 번호 인증 구현
- SignupAPIController 생성 (회원기능임에도 MemberAPIController와 구조가 달라 테스트 위해 일단 분리)
- 번호 입력 후 문자로 인증번호 수신, 사용자 입력 인증번호와 생성된 인증번호 비교 후, 일치하면 alert 띄움

## 주의사항
- 문자 전송에 필요한 API key 값 제거 (개인정보) 
- 로컬환경에서만 테스트 가능